### PR TITLE
Update installation-machine-requirements.adoc

### DIFF
--- a/modules/installation-machine-requirements.adoc
+++ b/modules/installation-machine-requirements.adoc
@@ -79,7 +79,7 @@ endif::ibm-z[]
 ====
 
 ifndef::ibm-z,ibm-power[]
-The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can choose between {op-system-first}, {op-system-base-full} 8.6 and later.
+The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can choose between {op-system-first}, {op-system-base-full} 8.8 and later.
 endif::ibm-z,ibm-power[]
 ifdef::ibm-z,ibm-power[]
 The bootstrap, control plane, and compute machines must use {op-system-first} as the operating system.


### PR DESCRIPTION
<!--- PR title format: --->

[[OCPBUGS-51360](https://issues.redhat.com/browse/OCPBUGS-51360) Wrong RHEL version is mentioned in UPI-vSphere installation

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18 [Needs to get backported till 4.13]

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Wrong RHEL version is mentioned in UPI-vSphere installation

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
